### PR TITLE
Update toolbox alias

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -20,10 +20,8 @@ export PATH
 # set editor variable
 export EDITOR="vi"
 
-# enter toolbox alias
-# NOTE: this is not ideal yet, we are looking for better ways
+# enter toolbox command
 alias dev='toolbox enter'
-alias nvim='toolbox run nvim'
 
 # file permissions command
 function fp() {


### PR DESCRIPTION
The `nvim` alias slowed down starting neovim inside of the container. Now when the container is up and running, neovim starts _blazingly fast_. Starting up the container is still kind of slow tho.