### PR TITLE
Update

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -14,3 +14,6 @@ bindkey -e
 HISTFILE="$HOME/.zsh_history"
 HISTSIZE=1000
 SAVEHIST=1000
+
+# set wordchars
+WORDCHARS=''

--- a/.zshrc
+++ b/.zshrc
@@ -17,3 +17,8 @@ SAVEHIST=1000
 
 # set wordchars
 WORDCHARS=''
+
+# set options
+setopt no_auto_menu
+setopt bash_auto_list
+setopt no_always_last_prompt

--- a/.zshrc
+++ b/.zshrc
@@ -22,3 +22,43 @@ WORDCHARS=''
 setopt no_auto_menu
 setopt bash_auto_list
 setopt no_always_last_prompt
+
+bindterm() {
+    local sequence widget
+    sequence="${terminfo[$1]}"
+    widget="$2"
+
+    [[ -z "$sequence" ]] && return 1
+    bindkey -- "$sequence" "$widget"
+}
+
+# bind keys using terminfo
+bindterm kbs   backward-delete-char
+bindterm khome beginning-of-line
+bindterm kend  end-of-line
+bindterm kich1 overwrite-mode
+bindterm kdch1 delete-char
+bindterm kcuu1 up-line-or-history
+bindterm kcud1 down-line-or-history
+bindterm kcub1 backward-char
+bindterm kcuf1 forward-char
+bindterm kpp   beginning-of-buffer-or-history
+bindterm knp   end-of-buffer-or-history
+
+# make sure the terminal is in application mode, when zle is
+# active. only then are the values from $terminfo valid.
+if (( ${+terminfo[smkx]} )) && (( ${+terminfo[rmkx]} )); then
+    zle-line-init() {
+        emulate -L zsh
+        printf '%s' ${terminfo[smkx]}
+    }
+    zle-line-finish() {
+        emulate -L zsh
+        printf '%s' ${terminfo[rmkx]}
+    }
+    zle -N zle-line-init
+    zle -N zle-line-finish
+fi
+
+# unfunction bindterm
+unfunction bindterm


### PR DESCRIPTION
This pull request includes significant changes to the `.zshrc` file to enhance terminal key bindings and improve user interaction. The most important changes are the addition of custom key bindings using terminfo sequences and the setting of various zsh options.

Enhancements to terminal key bindings:

* Added the `bindterm` function to bind keys using terminfo sequences. (`.zshrc`)
* Bound several keys (e.g., `kbs`, `khome`, `kend`) to corresponding zsh widgets for improved navigation and editing. (`.zshrc`)

Zsh options and settings:

* Set `WORDCHARS` to an empty string to modify word boundaries. (`.zshrc`)
* Configured zsh options such as `no_auto_menu`, `bash_auto_list`, and `no_always_last_prompt` to customize shell behavior. (`.zshrc`)

Terminal mode management:

* Ensured the terminal is in application mode when `zle` is active by defining `zle-line-init` and `zle-line-finish` functions. (`.zshrc`)