### PR TITLE
Set `no_auto_remove_slash` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,7 @@ WORDCHARS=''
 # set options
 setopt no_auto_menu
 setopt bash_auto_list
+setopt no_auto_remove_slash
 setopt no_always_last_prompt
 
 bindterm() {


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change sets the `no_auto_remove_slash` option.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R24): Added the `no_auto_remove_slash` option to the list of set options.