### PR TITLE
Set `sh_nullcmd` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -19,6 +19,7 @@ SAVEHIST=1000
 WORDCHARS=''
 
 # set options
+setopt sh_nullcmd
 setopt no_auto_menu
 setopt bash_auto_list
 setopt no_auto_remove_slash


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change sets an additional option to enable the `sh_nullcmd` feature.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R22): Added the `sh_nullcmd` option to the list of set options.