### PR TITLE
Set `ksh_arrays` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,7 @@ setopt hist_ignore_space
 WORDCHARS=''
 
 # Configure shell behaviour to be more like bash on Linux
+setopt ksh_arrays
 setopt sh_nullcmd
 setopt sh_word_split
 setopt bash_auto_list
@@ -33,7 +34,7 @@ PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 
 # Configure the path environment variable
 typeset -U path
-path=(~/.local/bin ~/.cabal/bin ~/.ghcup/bin $path)
+path=(~/.local/bin ~/.cabal/bin ~/.ghcup/bin ${path[@]})
 
 # Set editor and visual variables
 export EDITOR=ed


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file to improve shell behavior and path configuration.

Shell behavior improvements:

* Added `setopt ksh_arrays` to make array handling more consistent with ksh.

Path configuration improvements:

* Modified the `path` variable to use `${path[@]}` for better compatibility with existing paths.