### PR TITLE
Put qutotation marks around `${path[@]}`

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -42,7 +42,7 @@ PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 
 # Configure the path environment variable
 typeset -U path
-path=(~/.local/bin ~/.cabal/bin ~/.ghcup/bin ${path[@]})
+path=(~/.local/bin ~/.cabal/bin ~/.ghcup/bin "${path[@]}")
 
 # Set editor and visual variables
 export EDITOR=ed


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change ensures that the `path` array elements are properly quoted to handle paths with spaces.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L45-R45): Modified the `path` array to include quotes around the `${path[@]}` expansion to correctly handle paths with spaces.