### PR TITLE
Set `glob_subst` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -26,6 +26,7 @@ ZLE_REMOVE_SUFFIX_CHARS=''
 # Configure shell behaviour to be more like bash on Linux
 setopt sh_glob
 setopt ksh_glob
+setopt glob_subst
 setopt ksh_arrays
 setopt sh_nullcmd
 setopt sh_word_split


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change enables the `glob_subst` option to configure shell behavior to be more like bash on Linux.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R29): Added `setopt glob_subst` to configure shell behavior.