### PR TITLE
Set `interactive_comments` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -29,6 +29,7 @@ setopt ksh_glob
 setopt glob_subst
 setopt ksh_arrays
 setopt sh_nullcmd
+setopt interactive_comments
 setopt sh_word_split
 setopt bash_auto_list
 unsetopt nomatch


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change enables the `interactive_comments` option in the zsh configuration.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R32): Added `setopt interactive_comments` to allow comments in interactive shells.