### PR TITLE
Add custom unix line discard function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -39,6 +39,14 @@ unsetopt bare_glob_qual
 unsetopt always_last_prompt
 unsetopt auto_remove_slash
 
+# Create custom unix line discard function
+function unix_line_discard {
+	[[ $CURSOR -eq 0 ]] && printf '\a'
+	zle backward-kill-line
+}
+zle -N unix_line_discard
+bindkey '^U' unix_line_discard
+
 # Use a colorful prompt for better visibility
 PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file to enhance the shell's functionality and user experience. The most important change is the addition of a custom Unix line discard function.

Improvements to shell functionality:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R42-R49): Added a custom Unix line discard function and bound it to `Ctrl+U`. This function discards the current line, improving command line editing efficiency.