### PR TITLE
Refactor `unix_line_discard` function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -41,7 +41,9 @@ unsetopt auto_remove_slash
 
 # Create custom unix line discard function
 function unix_line_discard {
-	[[ $CURSOR -eq 0 ]] && printf '\a'
+	if [[ $CURSOR -eq 0 ]]; then
+		printf '\a' # beep
+	fi
 	zle backward-kill-line
 }
 zle -N unix_line_discard


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change modifies the `unix_line_discard` function to use an `if` statement instead of a single-line conditional.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L44-R46): Updated the `unix_line_discard` function to use an `if` statement for better readability.