### PR TITLE
Add test script

### DIFF
--- a/test
+++ b/test
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+@test "glob_subst" {
+	mkdir tmp && touch tmp/file{1,2}
+	result=$(zsh -ic 'foo="tmp/*"; print $foo')
+	rm tmp/file{1,2} && rmdir tmp
+	[ "$result" == "tmp/file1 tmp/file2" ]
+}
+
+@test "ksh_arrays" {
+	result=$(zsh -ic 'arr=(foo bar); echo $arr')
+	[ "$result" == "foo" ]
+}
+
+@test "ksh_glob" {
+	mkdir tmp && touch tmp/file{1,2}
+	result=$(zsh -ic 'echo tmp/@(file*)')
+	rm tmp/file{1,2} && rmdir tmp
+	[ "$result" == "tmp/file1 tmp/file2" ]
+}
+
+@test "no_bad_pattern" {
+	result="$(zsh -ic 'print [-')"
+	[ "$result" == "[-" ]
+}
+
+@test "no_bare_glob_qual" {
+	mkdir tmp && touch tmp/file{1,2}
+	result=$(zsh -ic 'cd tmp; print *(.)')
+	rm tmp/file{1,2} && rmdir tmp
+	[ "$result" == "*(.)" ]
+}
+
+@test "no_nomatch" {
+	result="$(zsh -ic 'print nosuchfile*')"
+	[ "$result" == "nosuchfile*" ]
+}
+
+@test "sh_glob" {
+	mkdir tmp && touch tmp/file{1,2}
+	result=$(zsh -ic 'echo tmp/(file1|file2)')
+	rm tmp/file{1,2} && rmdir tmp
+	[ "$result" == "tmp/(file1|file2)" ]
+}


### PR DESCRIPTION
This pull request introduces a new test suite using the Bats testing framework to validate various shell behaviors in `zsh`. The tests cover a range of functionalities including glob substitution, array handling, and pattern matching.

New tests added:

* [`glob_subst`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Tests glob substitution with a wildcard pattern.
* [`ksh_arrays`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Tests array handling by printing the first element of an array.
* [`ksh_glob`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Tests glob patterns with the `@` qualifier.
* [`no_bad_pattern`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Ensures that a specific pattern does not cause errors.
* [`no_bare_glob_qual`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Tests bare glob qualifiers in a specific directory.
* [`no_nomatch`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Ensures that unmatched patterns are returned as-is.
* [`sh_glob`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R1-R44): Tests shell-style glob patterns with alternation.