### PR TITLE
Add test for `sh_word_split`

### DIFF
--- a/test
+++ b/test
@@ -42,3 +42,8 @@
 	rm tmp/file{1,2} && rmdir tmp
 	[ "$result" == "tmp/(file1|file2)" ]
 }
+
+@test "sh_word_split" {
+	result=$(zsh -ic 'x="foo bar"; set -- $x; echo $1')
+	[ "$result" == "foo" ]
+}


### PR DESCRIPTION
This pull request includes a small change to the `test` file. The change adds a new test case for `sh_word_split` to ensure that word splitting behaves as expected in a Zsh environment.

* [`test`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R45-R49): Added a new test case `sh_word_split` to verify that word splitting correctly assigns the first word to `$1` in Zsh.