### PR TITLE
Unset `equals` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -32,6 +32,7 @@ setopt sh_nullcmd
 setopt interactive_comments
 setopt sh_word_split
 setopt bash_auto_list
+unsetopt equals
 unsetopt nomatch
 unsetopt auto_menu
 unsetopt bad_pattern

--- a/test
+++ b/test
@@ -31,6 +31,11 @@
 	[ "$result" == "*(.)" ]
 }
 
+@test "no_equals" {
+	result=$(zsh -ic 'echo =cc')
+	[ "$result" == "=cc" ]
+}
+
 @test "no_nomatch" {
 	result="$(zsh -ic 'print nosuchfile*')"
 	[ "$result" == "nosuchfile*" ]


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` configuration and the `test` file to modify shell behavior and add a new test case.

Changes to `.zshrc`:

* [`setopt sh_nullcmd`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R35): Unset the `equals` option to change how the shell handles the `=` character.

Changes to `test`:

* Added a new test case `no_equals` to verify that the `equals` option is unset and the `=` character is treated as a literal string.