### PR TITLE
Set `sh_file_expansion` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -29,6 +29,7 @@ setopt ksh_glob
 setopt glob_subst
 setopt ksh_arrays
 setopt sh_nullcmd
+setopt sh_file_expansion
 setopt interactive_comments
 setopt sh_word_split
 setopt bash_auto_list

--- a/test
+++ b/test
@@ -41,6 +41,12 @@
 	[ "$result" == "nosuchfile*" ]
 }
 
+@test "sh_file_expansion" {
+	result=$(zsh -ic 'foo="~/.zshrc"; print $foo')
+	# shellcheck disable=SC2088
+	[ "$result" == "~/.zshrc" ]
+}
+
 @test "sh_glob" {
 	mkdir tmp && touch tmp/file{1,2}
 	result=$(zsh -ic 'echo tmp/(file1|file2)')


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` configuration file and the `test` script to enable and verify the `sh_file_expansion` option.

Configuration changes:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R32): Added the `setopt sh_file_expansion` option to enable file expansion.

Testing changes:

* [`test`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R44-R49): Added a new test case to verify the `sh_file_expansion` option, ensuring that a variable containing a tilde (`~`) is correctly expanded.