### PR TITLE
Set `no_function_argzero` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -33,6 +33,7 @@ setopt sh_file_expansion
 setopt interactive_comments
 setopt sh_word_split
 setopt bash_auto_list
+setopt no_function_argzero
 unsetopt equals
 unsetopt nomatch
 unsetopt auto_menu

--- a/.zshrc
+++ b/.zshrc
@@ -24,23 +24,23 @@ WORDCHARS=''
 ZLE_REMOVE_SUFFIX_CHARS=''
 
 # Configure shell behaviour to be more like bash on Linux
-setopt sh_glob
-setopt ksh_glob
-setopt glob_subst
-setopt ksh_arrays
-setopt sh_nullcmd
-setopt sh_file_expansion
-setopt interactive_comments
-setopt sh_word_split
 setopt bash_auto_list
-setopt no_function_argzero
-setopt no_equals
-setopt no_nomatch
+setopt glob_subst
+setopt interactive_comments
+setopt ksh_arrays
+setopt ksh_glob
+setopt no_always_last_prompt
 setopt no_auto_menu
+setopt no_auto_remove_slash
 setopt no_bad_pattern
 setopt no_bare_glob_qual
-setopt no_always_last_prompt
-setopt no_auto_remove_slash
+setopt no_equals
+setopt no_function_argzero
+setopt no_nomatch
+setopt sh_file_expansion
+setopt sh_glob
+setopt sh_nullcmd
+setopt sh_word_split
 
 # Create custom unix line discard function
 function unix_line_discard {

--- a/.zshrc
+++ b/.zshrc
@@ -34,13 +34,13 @@ setopt interactive_comments
 setopt sh_word_split
 setopt bash_auto_list
 setopt no_function_argzero
-unsetopt equals
-unsetopt nomatch
-unsetopt auto_menu
-unsetopt bad_pattern
-unsetopt bare_glob_qual
-unsetopt always_last_prompt
-unsetopt auto_remove_slash
+setopt no_equals
+setopt no_nomatch
+setopt no_auto_menu
+setopt no_bad_pattern
+setopt no_bare_glob_qual
+setopt no_always_last_prompt
+setopt no_auto_remove_slash
 
 # Create custom unix line discard function
 function unix_line_discard {

--- a/test
+++ b/test
@@ -31,6 +31,11 @@
 	[ "$result" == "*(.)" ]
 }
 
+@test "no_function_argzero" {
+	result=$(zsh -ic 'function foo { echo $0 }; foo')
+	[ "$result" == "zsh" ]
+}
+
 @test "no_equals" {
 	result=$(zsh -ic 'echo =cc')
 	[ "$result" == "=cc" ]


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` configuration file and the `test` file to improve shell behavior and add new test cases.

Improvements to shell behavior:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L27-L42): Reconfigured several shell options to make the shell behavior more like bash on Linux. Key changes include enabling `bash_auto_list`, `interactive_comments`, and `no_auto_menu`, among others.

Additional test cases:

* [`test`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08R34-R38): Added a new test case for the `no_function_argzero` option to ensure that the function argument zero behaves as expected.