### PR TITLE
Rewrite `path` config

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -40,10 +40,6 @@ setopt sh_glob
 setopt sh_nullcmd
 setopt sh_word_split
 
-# Configure the path environment variable
-typeset -U path
-path=(~/.local/bin ~/.cabal/bin ~/.ghcup/bin "${path[@]}")
-
 # Set editor and visual variables
 export EDITOR=ed
 export VISUAL=vi
@@ -70,6 +66,15 @@ linux*)
 	alias ls='ls --color=auto'
 	;;
 esac
+
+# Configure the path environment variable
+typeset -U path
+path=(
+	"$HOME/.local/bin"
+	"$HOME/.cabal/bin"
+	"$HOME/.ghcup/bin"
+	"${path[@]}"
+)
 
 # Add command not found handler for Debian-based systems
 function command_not_found_handler {


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file, specifically related to the configuration of the path environment variable. The most important changes include relocating the path configuration block to a different section of the file.

Changes to path configuration:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L43-L46): Removed the path configuration block from its original location.
* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R70-R78): Added the path configuration block under the `linux*)` case section.