### PR TITLE
Update Homebrew config

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -53,7 +53,7 @@ case "$OSTYPE" in
 darwin*)
 	export CLICOLOR=1
 	# Add Homebrew to path if it is installed
-	if [[ -d "/opt/homebrew" ]]; then
+	if [[ -x /opt/homebrew/bin/brew ]]; then
 		eval "$(/opt/homebrew/bin/brew shellenv)"
 	fi
 	;;


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change modifies the condition to check if Homebrew is installed by verifying the existence of the `brew` executable rather than just the directory. 

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L56-R56): Changed the condition from checking if the directory `/opt/homebrew` exists to checking if the `brew` executable is present at `/opt/homebrew/bin/brew`.