### PR TITLE
Rewrite `unix_line_discard` function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -88,10 +88,10 @@ function command_not_found_handler {
 
 # Create custom unix line discard function
 function unix_line_discard {
-	if [[ $CURSOR -eq 0 ]]; then
-		printf '\a'
-	fi
-	zle backward-kill-line
+	case "$CURSOR" in
+	0) zle beep ;;
+	*) zle backward-kill-line ;;
+	esac
 }
 zle -N unix_line_discard
 bindkey '^U' unix_line_discard


### PR DESCRIPTION
This pull request includes a change to the `.zshrc` file to improve the `unix_line_discard` function. The change simplifies the condition for determining the cursor position and executing the appropriate action.

Improvements to `unix_line_discard` function:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L91-R94): Replaced the `if` statement with a `case` statement to handle cursor position checks more succinctly and improve readability.