### PR TITLE
Enable `ksh` emulation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -18,27 +18,18 @@ ZLE_REMOVE_SUFFIX_CHARS=''
 # Use a colorful prompt for better visibility
 PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 
-# Configure shell behaviour to be more like bash/ksh
+# Enable KornShell emulation
+emulate ksh
+
+# Customize interactive shell behaviour
 setopt append_history
 setopt bash_auto_list
-setopt glob_subst
 setopt hist_ignore_dups
 setopt hist_ignore_space
 setopt interactive_comments
-setopt ksh_arrays
-setopt ksh_glob
 setopt no_always_last_prompt
 setopt no_auto_menu
 setopt no_auto_remove_slash
-setopt no_bad_pattern
-setopt no_bare_glob_qual
-setopt no_equals
-setopt no_function_argzero
-setopt no_nomatch
-setopt sh_file_expansion
-setopt sh_glob
-setopt sh_nullcmd
-setopt sh_word_split
 
 # Set editor and visual variables
 export EDITOR=ed


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file to improve shell behavior and enable KornShell emulation. The most important changes include enabling KornShell emulation and customizing interactive shell options.

Shell behavior improvements:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L21-L41): Enabled KornShell emulation by adding the `emulate ksh` command.
* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L21-L41): Removed several `setopt` options that are no longer necessary after enabling KornShell emulation, such as `glob_subst`, `ksh_arrays`, `ksh_glob`, and others.