### PR TITLE
Revert "Enable `ksh` emulation"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -18,18 +18,27 @@ ZLE_REMOVE_SUFFIX_CHARS=''
 # Use a colorful prompt for better visibility
 PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 
-# Enable KornShell emulation
-emulate ksh
-
-# Customize interactive shell behaviour
+# Configure shell behaviour to be more like bash/ksh
 setopt append_history
 setopt bash_auto_list
+setopt glob_subst
 setopt hist_ignore_dups
 setopt hist_ignore_space
 setopt interactive_comments
+setopt ksh_arrays
+setopt ksh_glob
 setopt no_always_last_prompt
 setopt no_auto_menu
 setopt no_auto_remove_slash
+setopt no_bad_pattern
+setopt no_bare_glob_qual
+setopt no_equals
+setopt no_function_argzero
+setopt no_nomatch
+setopt sh_file_expansion
+setopt sh_glob
+setopt sh_nullcmd
+setopt sh_word_split
 
 # Set editor and visual variables
 export EDITOR=ed


### PR DESCRIPTION
Reverts notfirefox/zsh-config#61. This currently somehow breaks auto completion for apt sub-commands, e.g.
```sh
sudo apt autore<TAB>
```