### PR TITLE
Rewrite aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -48,24 +48,20 @@ export VISUAL=vi
 export EXINIT="set nofl"
 export NEXINIT="$EXINIT filec=\	"
 
-# Enable colors for common commands such as ls and grep
-case "$OSTYPE" in
-darwin*)
-	export CLICOLOR=1
-	# Add Homebrew to path if it is installed
-	if [[ -x /opt/homebrew/bin/brew ]]; then
-		eval "$(/opt/homebrew/bin/brew shellenv)"
-	fi
-	;;
-linux*)
-	if [[ -x /usr/bin/dircolors ]]; then
-		eval "$(dircolors -b)"
-	fi
-	alias diff='diff --color=auto'
-	alias grep='grep --color=auto'
+# Add Homebrew to path if it is installed
+if [[ -x /opt/homebrew/bin/brew ]]; then
+	eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# Enable colors for commands such as ls, diff and grep
+if [[ -x /usr/bin/dircolors ]]; then
+	eval "$(/usr/bin/dircolors -b)"
 	alias ls='ls --color=auto'
-	;;
-esac
+else
+	export CLICOLOR=1
+fi
+alias diff='diff --color=auto'
+alias grep='grep --color=auto'
 
 # Configure the path environment variable
 typeset -U path


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file to enhance the color settings for common commands and streamline the configuration.

Enhancements to color settings:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L51-L68): Removed the conditional logic based on `OSTYPE` and consolidated the color settings for commands such as `ls`, `diff`, and `grep`. The `dircolors` command is now evaluated directly, and the `CLICOLOR` environment variable is set as a fallback.