### PR TITLE
Restructure `ls` config

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,8 +55,8 @@ fi
 
 # Enable colors for commands such as ls, diff and grep
 if [[ -x /usr/bin/dircolors ]]; then
-	eval "$(/usr/bin/dircolors -b)"
 	alias ls='ls --color=auto'
+	eval "$(/usr/bin/dircolors -b)"
 else
 	export CLICOLOR=1
 fi


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change reorders the `eval "$(/usr/bin/dircolors -b)"` command to be executed after setting the `ls` alias. 

Change in `.zshrc`:

* Moved the `eval "$(/usr/bin/dircolors -b)"` command to execute after setting the `ls` alias to ensure proper color configuration.