### PR TITLE
Update `path` config

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -65,12 +65,10 @@ alias grep='grep --color=auto'
 
 # Configure the path environment variable
 typeset -U path
-path=(
-	"$HOME/.local/bin"
-	"$HOME/.cabal/bin"
-	"$HOME/.ghcup/bin"
-	"${path[@]}"
-)
+if [[ -x $HOME/.ghcup/bin/ghcup ]]; then
+	path=("$HOME/.cabal/bin" "$HOME/.ghcup/bin" "${path[@]}")
+fi
+path=("$HOME/.local/bin" "${path[@]}")
 
 # Add command not found handler for Debian-based systems
 function command_not_found_handler {


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change modifies the configuration of the `path` environment variable to conditionally include the GHCup binary directory only if the `ghcup` executable is present.