### PR TITLE
Add `LSCOLORS` environment variable

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -59,6 +59,7 @@ if [[ -x /usr/bin/dircolors ]]; then
 	alias ls='ls --color=auto'
 else
 	export CLICOLOR=1
+	export LSCOLORS="ExGxFxdaCxDaDahbadecac"
 fi
 alias diff='diff --color=auto'
 alias grep='grep --color=auto'


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change sets the `LSCOLORS` environment variable to customize the color scheme for the `ls` command.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R62): Added `LSCOLORS="ExGxFxdaCxDaDahbadecac"` to set a custom color scheme for the `ls` command.