### PR TITLE
Update ls color config for `darwin*|freebsd*`

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -57,9 +57,9 @@ fi
 if [[ -x /usr/bin/dircolors ]]; then
 	eval "$(/usr/bin/dircolors -b)"
 	alias ls='ls --color=auto'
-else
-	export CLICOLOR=1
+elif [[ $OSTYPE == @(darwin*|freebsd*) ]]; then
 	export LSCOLORS="ExGxFxdaCxDaDahbadecac"
+	alias ls='ls -G'
 fi
 alias diff='diff --color=auto'
 alias grep='grep --color=auto'


### PR DESCRIPTION
Check the `OSTYPE` before attempting to utilize features that are specific to the ls(1) binary on Darwin and FreeBSD. Furthermore replace `CLICOLOR` with `ls -G`, because the environment variable may be removed in the future [1].

[1] https://github.com/freebsd/freebsd-src/commit/72ad696aa1a3a2c3225ed089f01a6cdea57db351