### PR TITLE
Remove double quotes inside of `[[ ]]`

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -97,7 +97,7 @@ function xterm_title_precmd {
 }
 
 # Install zsh hook to set the terminal title
-if [[ "$TERM" == @(rxvt*|xterm*) ]]; then
+if [[ $TERM == @(rxvt*|xterm*) ]]; then
 	autoload -Uz add-zsh-hook
 	add-zsh-hook -Uz precmd xterm_title_precmd
 fi


### PR DESCRIPTION
This pull request includes a minor change to the `.zshrc` file. The change removes unnecessary double quotes around the `$TERM` variable in a conditional statement.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L100-R100): Removed unnecessary double quotes around the `$TERM` variable in the conditional statement below the `xterm_title_precmd` function.