### PR TITLE
Use `OSTYPE` instead of checking for dircolors

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -61,7 +61,7 @@ fi
 path=("$HOME/.local/bin" "${path[@]}")
 
 # Enable colors for commands such as ls, diff and grep
-if [[ -x /usr/bin/dircolors ]]; then
+if [[ $OSTYPE == linux-gnu ]]; then
 	eval "$(/usr/bin/dircolors -b)"
 	alias ls='ls --color=auto'
 elif [[ $OSTYPE == @(darwin*|freebsd*) ]]; then


### PR DESCRIPTION
This pull request includes a change to the `.zshrc` file to improve compatibility across different operating systems. The change modifies the condition for enabling colors for commands such as `ls`, `diff`, and `grep`.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L64-R64): Changed the condition from checking for the existence of `/usr/bin/dircolors` to checking if `OSTYPE` is `linux-gnu` to ensure compatibility across different operating systems.