### PR TITLE
Add colors to `kshcompat` script

### DIFF
--- a/kshcompat
+++ b/kshcompat
@@ -4,6 +4,11 @@
 # shellcheck disable=SC2016
 # shellcheck disable=SC2088
 
+bold=$(tput bold)
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+normal=$(tput sgr0)
+
 # Shell script exit code
 exit_code=0
 
@@ -15,9 +20,11 @@ run_test() {
 	result=$(zsh -ic "$command")
 
 	if [ "$result" = "$expected" ]; then
-		echo "PASS: $desc"
+		printf "${bold}${green}PASS:${normal} "
+		printf "$desc\n"
 	else
-		echo "FAIL: $desc (expected: '$expected', got: '$result')"
+		printf "${bold}${red}FAIL:${normal} "
+		printf "$desc (expected: '$expected', got: '$result')\n"
 		exit_code=1  # Mark as failed
 	fi
 }


### PR DESCRIPTION
This pull request includes changes to enhance the visual output of the test results in the `kshcompat` script by adding color formatting for pass and fail messages.

Improvements to test result output:

* [`kshcompat`](diffhunk://#diff-30af60ad6f1f1001f52d03b3d0c014dc05d46e1e3fc9872021cdd5bedb8cee1bR7-R11): Added variables for bold, red, green, and normal text formatting using `tput` to enable colored output.
* `run_test() {` in `kshcompat`: Updated the pass and fail messages to use the newly defined color formatting for better readability.