### PR TITLE
Don't use variables in the `printf` format string

### DIFF
--- a/kshcompat
+++ b/kshcompat
@@ -20,11 +20,11 @@ run_test() {
 	result=$(zsh -ic "$command")
 
 	if [ "$result" = "$expected" ]; then
-		printf "${bold}${green}PASS:${normal} "
-		printf "$desc\n"
+		printf "%sPASS:%s %s\n" "${bold}${green}" "${normal}" "${desc}"
 	else
-		printf "${bold}${red}FAIL:${normal} "
-		printf "$desc (expected: '$expected', got: '$result')\n"
+		printf "%sFAIL:%s %s " "${bold}${red}" "${normal}" "${desc}"
+		printf "(expected: '%s', got: '%s')\n" "${expected}" "${result}"
+
 		exit_code=1  # Mark as failed
 	fi
 }


### PR DESCRIPTION
This pull request includes a small change to the `run_test()` function in the `kshcompat` file. The change simplifies the `printf` statements for both the pass and fail cases by using a more concise format string.

Changes to `run_test()` function:

* Simplified `printf` statements for both pass and fail cases to use a more concise format string.