### PR TITLE
Enable `ksh` emulation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,9 @@
 # Enable subcommand completion
-autoload -Uz compinit && compinit
+emulate zsh -c 'autoload -Uz compinit'
+compinit
+
+# Enable ksh emulation
+emulate -R ksh
 
 # Use emacs style keybindings for better compatibility
 bindkey -e
@@ -18,27 +22,16 @@ ZLE_REMOVE_SUFFIX_CHARS=''
 # Use a colorful prompt for better visibility
 PROMPT="%F{green}%B%n@%m%b%f:%F{blue}%B%~%b%f%(!.#.$) "
 
-# Configure shell behaviour to be more like bash/ksh
+# Configure interactive shell behaviour
 setopt append_history
 setopt bash_auto_list
-setopt glob_subst
 setopt hist_ignore_dups
 setopt hist_ignore_space
-setopt interactive_comments
-setopt ksh_arrays
-setopt ksh_glob
 setopt no_always_last_prompt
 setopt no_auto_menu
 setopt no_auto_remove_slash
-setopt no_bad_pattern
-setopt no_bare_glob_qual
-setopt no_equals
-setopt no_function_argzero
-setopt no_nomatch
-setopt sh_file_expansion
-setopt sh_glob
-setopt sh_nullcmd
-setopt sh_word_split
+setopt no_single_line_zle
+setopt prompt_percent
 
 # Set editor and visual variables
 export EDITOR=ed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Minimal Zsh Config
 - Linux or macOS
 
 ## :package: Installation
+Disable global `compinit` on Ubuntu.
+```sh
+echo 'skip_global_compinit=1' > ~/.zshenv
+```
+
 Download the config file to `~/.zshrc`.
 ```sh
 curl -o ~/.zshrc "https://raw.githubusercontent.com/notfirefox/zsh-config/main/.zshrc"


### PR DESCRIPTION
This pull request includes several changes to the `.zshrc` configuration file and an update to the `README.md` file. The most important changes focus on improving shell behavior and updating documentation for installation.

Changes to `.zshrc` configuration:

* Enabled `ksh` emulation mode by adding `emulate -R ksh` and modified the way `compinit` is loaded for better compatibility.
* Updated shell options to refine interactive behavior, such as removing several `setopt` options and adding `no_single_line_zle` and `prompt_percent`.

Documentation updates:

* Added instructions to disable global `compinit` on Ubuntu in the `README.md` file.