### PR TITLE
Customize command-line editing behavior

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -74,6 +74,15 @@ function command_not_found_handler {
 	return 127
 }
 
+# Custom backward and forward word function
+bindkey '\eb' emacs-backward-word
+bindkey '\ef' emacs-forward-word
+
+# Custom backward kill word function
+autoload -Uz backward-kill-word-match
+zstyle ':zle:backward-kill-word' word-style space
+zle -N backward-kill-word backward-kill-word-match
+
 # Create custom unix line discard function
 function unix_line_discard {
 	case "$CURSOR" in


### PR DESCRIPTION
This pull request includes custom key bindings and functions to enhance text navigation and editing in the `.zshrc` configuration file.

Text navigation and editing enhancements:

* Added custom key bindings for moving backward and forward by word using `emacs-backward-word` and `emacs-forward-word`. (`.zshrc`)
* Introduced a custom backward kill word function with `backward-kill-word-match` and configured it with `zstyle`. (`.zshrc`)